### PR TITLE
chore(APP-14354): add pnode engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "dist"
   ],
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=20.10"
+  },
   "packageManager": "yarn@1.22.22",
   "devDependencies": {
     "@allthings/eslint-config": "2.1.1",


### PR DESCRIPTION
This PR implements ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated minimum required Node.js version to 20.10 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->